### PR TITLE
Use mock event data to render meetup panels on home page.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,8 +69,8 @@ gulp.task('html', function () {
 // Watch for changes in JS, Sass, and HTML files, then Lint,
 // Uglify, Process the Sass, and reload the browser automatically
 gulp.task('watch', function () {
-    gulp.watch('js/*.js', ['lint']);
-    gulp.watch('js/*.js', ['uglify']);
+    gulp.watch('js/**/*.js', ['lint']);
+    gulp.watch('js/**/*.js', ['uglify']);
     gulp.watch('sass/*', ['sass']);
     gulp.watch('*.html', ['html']);
 

--- a/index.html
+++ b/index.html
@@ -8,9 +8,11 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <link rel="stylesheet" href="css/style.css">
     <!-- JS -->
-    <script   src="https://code.jquery.com/jquery-2.2.4.min.js"   integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="   crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.2/lodash.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" charset="utf-8"></script>
     <script src="js/myjs.js" charset="utf-8"></script>
+    <script src="js/views/index-meetup.js" charset="utf-8"></script>
     <!-- Fonts -->
   </head>
   <body>

--- a/js/views/index-meetup.js
+++ b/js/views/index-meetup.js
@@ -32,7 +32,8 @@
   $(function () {
     var meetupEventDataRequest = $.getJSON('js/free-code-camp-events.mock.json');
     meetupEventDataRequest.then(function (data) {
-      var topResults = _.take(_.get(data, 'results'), numberOfPanelsToDisplay);
+      var sortedResults = _.sortBy(_.get(data, 'results'), 'time').reverse();
+      var topResults = _.take(sortedResults, numberOfPanelsToDisplay);
       var panels = _.map(topResults, function (event) {
         var eventTitle = _.get(event, 'name');
         var eventStatus = _.get(event, 'status');

--- a/js/views/index-meetup.js
+++ b/js/views/index-meetup.js
@@ -4,7 +4,7 @@
   var numberOfPanelsToDisplay = 3;
   var statusToHumanReadableDict = {
     'past': 'You just missed!',
-    'soon': 'Happening Soon'
+    'upcoming': 'Happening Soon'
   }
   function getHumanReadableStatus(eventStatus) {
     return statusToHumanReadableDict[eventStatus];

--- a/js/views/index-meetup.js
+++ b/js/views/index-meetup.js
@@ -1,0 +1,53 @@
+// Module pattern for script isolation.
+(function () {
+  var targetContentDivId = 'meetup-panels';
+  var numberOfPanelsToDisplay = 3;
+  var statusToHumanReadableDict = {
+    'past': 'You just missed!',
+    'soon': 'Happening Soon'
+  }
+  function getHumanReadableStatus(eventStatus) {
+    return statusToHumanReadableDict[eventStatus];
+  }
+  function generatePanelHTML(variablesObject) {
+    return _.template(
+      '<div class="meetupPanel">' +
+        '<h4><%- timeStatus %></h4>' +
+        '<a href="">' +
+          // update this to grab the location
+          '<img src="images/placeHolder.jpg" alt="<%- timeStatus %>">' +
+        '</a>' +
+        '<h4><%- title %></h4>' +
+        '<p><%= description %></p>' +
+        '<a href="<%- joinUrl %>"><div class="fccBtn-small">Join us!</div></a>' +
+      '</div>'
+    )({
+      timeStatus: variablesObject.timeStatus,
+      title: variablesObject.eventTitle,
+      description: variablesObject.eventDescription,
+      joinUrl: variablesObject.eventUrl
+    });
+  }
+  // Run only when document is ready.
+  $(function () {
+    var meetupEventDataRequest = $.getJSON('js/free-code-camp-events.mock.json');
+    meetupEventDataRequest.then(function (data) {
+      var topResults = _.take(_.get(data, 'results'), numberOfPanelsToDisplay);
+      var panels = _.map(topResults, function (event) {
+        var eventTitle = _.get(event, 'name');
+        var eventStatus = _.get(event, 'status');
+        var flavoredEventStatus = getHumanReadableStatus(eventStatus);
+        var eventDescription = _.get(event, 'description');
+        var eventUrl = _.get(event, 'event_url');
+        return generatePanelHTML({
+          timeStatus: flavoredEventStatus,
+          eventTitle: eventTitle,
+          eventDescription: eventDescription,
+          eventUrl: eventUrl
+        });
+      });
+      var innerHtml = panels.join('');
+      document.getElementById(targetContentDivId).innerHTML = innerHtml;
+    });
+  });
+})();

--- a/sass/_meetupsection.sass
+++ b/sass/_meetupsection.sass
@@ -34,7 +34,7 @@
 .meetupPanel
   background-color: white
   height: auto
-  max-height: 400px
+  min-height: 400px
   width: 300px
   position: relative
   float: left

--- a/views/index-meetup.html
+++ b/views/index-meetup.html
@@ -2,43 +2,9 @@
   <div class="block">
     <h3>Upcoming Meetups</h3>
   </div>
-<div class="container ">
-
-  <div class="container">
-
+  <div class="container ">
+    <!-- TODO: Find out why this second "container" tag is required for panel styling -->
+    <div class="container"></div>
+    <div id="meetup-panels"></div>
   </div>
-  <div class="meetupPanel">
-    <h4>You just missed</h4>
-    <a href="">
-      <!-- update this to grab the location-->
-      <img src="images/placeHolder.jpg" alt="Past Meetup">
-    </a>
-    <h4>update this with api to grab the title and if it's super long maybe we can add more rules to this</h4>
-    <p>update this with the api to import the details.  Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like)</p>
-    <!-- update this to the past link -->
-    <a href=""><div class="fccBtn-small">Join us!</div></a>
-  </div>
-  <div class="meetupPanel">
-    <h4>Happening Soon</h4>
-    <a href="">
-      <!-- update this to grab the location-->
-      <img src="images/placeHolder.jpg" alt="Current Meetup">
-    </a>
-    <h4>update this with api to grab the title and if it's super long maybe we can add more rules to this</h4>
-    <p>update this with the api to import the details.  Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like)</p>
-    <!-- update this to the current link -->
-    <a href=""><div class="fccBtn-small">Join us!</div></a>
-  </div>
-  <div class="meetupPanel">
-    <h4>Upcoming</h4>
-    <a href="">
-      <!-- updatethiswithapi to grab the location-->
-      <img src="images/placeHolder.jpg" alt="Next Meetup">
-    </a>
-    <h4>update this with api to grab the title and if it's super long maybe we can add more rules to this</h4>
-    <p>update this with the api to import the details.  Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like)</p>
-    <!-- update this to the future link -->
-    <a href=""><div class="fccBtn-small">Join us!</div></a>
-  </div>
-</div>
 </div>


### PR DESCRIPTION
Updated gulpfile to watch deeply (vs. watch shallow) the JS files.  Update sass panel syle "max-height" to "min-height".  Added lodash via CDN to index page.  Created script that templates panels with easily configurable "display X panels" where X is how many panels to display.  Script is utilizing .mock.json event data pulled from meetup.com's API.

The end result looks like:
<img width="1304" alt="screen shot 2016-11-25 at 6 25 54 pm" src="https://cloud.githubusercontent.com/assets/3106250/20636533/aa80cfe6-b33c-11e6-9ed2-1327254a0bbb.png">

Please review @gwenf @TheJaredWilcurt @mattattaq

Edit: This PR is related to https://github.com/Free-Code-Camp-Indy/free-code-camp-indy.github.io/issues/3 and utilizes mocks created in https://github.com/Free-Code-Camp-Indy/free-code-camp-indy.github.io/pull/18.  This will not break once https://github.com/Free-Code-Camp-Indy/free-code-camp-indy.github.io/pull/26 is merged.